### PR TITLE
Does not store responses with Set-Cookie headers by default, similar to NGINX

### DIFF
--- a/rfc9111/shared.go
+++ b/rfc9111/shared.go
@@ -153,7 +153,7 @@ func (s *Shared) Storable(req *http.Request, res *http.Response, now time.Time) 
 		return false, time.Time{}
 	}
 
-	// In RFC 9111, Servers that wish to control caching of responses with Set-Cookie headers are encouraged to emit appropriate Cache-Control response header fields (https://httpwg.org/specs/rfc9111.html#rfc.section.7.3)
+	// In RFC 9111, Servers that wish to control caching of responses with Set-Cookie headers are encouraged to emit appropriate Cache-Control response header fields (see https://httpwg.org/specs/rfc9111.html#rfc.section.7.3).
 	// But to beat on the safe side, this package does not store responses with Set-Cookie headers by default, similar to NGINX.
 	// THIS IS NOT RFC 9111.
 	if req.Header.Get("Set-Cookie") != "" && !s.storeRequestWithSetCookieHeader {

--- a/rfc9111/shared.go
+++ b/rfc9111/shared.go
@@ -15,6 +15,7 @@ type Shared struct {
 	understoodStatusCodes             []int
 	heuristicallyCacheableStatusCodes []int
 	heuristicExpirationRatio          float64
+	storeRequestWithSetCookieHeader   bool
 	extendedRules                     []ExtendedRule
 }
 
@@ -61,6 +62,14 @@ func HeuristicExpirationRatio(ratio float64) SharedOption {
 			return ErrNegativeRatio
 		}
 		s.heuristicExpirationRatio = ratio
+		return nil
+	}
+}
+
+// StoreRequestWithSetCookieHeader enables storing request with Set-Cookie header.
+func StoreRequestWithSetCookieHeader() SharedOption {
+	return func(s *Shared) error {
+		s.storeRequestWithSetCookieHeader = true
 		return nil
 	}
 }
@@ -141,6 +150,13 @@ func (s *Shared) Storable(req *http.Request, res *http.Response, now time.Time) 
 	// - if the cache is shared: the Authorization header field is not present in the request (see https://httpwg.org/specs/rfc9111.html#rfc.section.11.6.2 of [HTTP]) or a response directive is present that explicitly allows shared caching (see https://httpwg.org/specs/rfc9111.html#rfc.section.3.5);
 	// In this specification, the following response directives have such an effect: must-revalidate (https://httpwg.org/specs/rfc9111.html#rfc.section.5.2.2.2), public (https://httpwg.org/specs/rfc9111.html#rfc.section.5.2.2.9), and s-maxage (https://httpwg.org/specs/rfc9111.html#rfc.section.5.2.2.10).
 	if req.Header.Get("Authorization") != "" && !rescc.MustRevalidate && !rescc.Public && rescc.SMaxAge == nil {
+		return false, time.Time{}
+	}
+
+	// Servers that wish to control caching of these responses are encouraged to emit appropriate Cache-Control response header fields (https://httpwg.org/specs/rfc9111.html#rfc.section.7.3)
+	// But to beat on the safe side, this package does not store responses with Set-Cookie headers by default, similar to NGINX.
+	// THIS IS NOT RFC 9111.
+	if req.Header.Get("Set-Cookie") != "" && !s.storeRequestWithSetCookieHeader {
 		return false, time.Time{}
 	}
 

--- a/rfc9111/shared.go
+++ b/rfc9111/shared.go
@@ -153,7 +153,7 @@ func (s *Shared) Storable(req *http.Request, res *http.Response, now time.Time) 
 		return false, time.Time{}
 	}
 
-	// Servers that wish to control caching of these responses are encouraged to emit appropriate Cache-Control response header fields (https://httpwg.org/specs/rfc9111.html#rfc.section.7.3)
+	// In RFC 9111, Servers that wish to control caching of responses with Set-Cookie headers are encouraged to emit appropriate Cache-Control response header fields (https://httpwg.org/specs/rfc9111.html#rfc.section.7.3)
 	// But to beat on the safe side, this package does not store responses with Set-Cookie headers by default, similar to NGINX.
 	// THIS IS NOT RFC 9111.
 	if req.Header.Get("Set-Cookie") != "" && !s.storeRequestWithSetCookieHeader {

--- a/rfc9111/shared_test.go
+++ b/rfc9111/shared_test.go
@@ -302,6 +302,24 @@ func TestShared_Storable(t *testing.T) {
 			time.Time{},
 		},
 		{
+			"GET Set-Cookie: k=v 200 Cache-Control: max-age=15 -> No Store",
+			&http.Request{
+				Method: http.MethodGet,
+				Header: http.Header{
+					"Set-Cookie": []string{"k=v"},
+				},
+			},
+			&http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Cache-Control": []string{"max-age=15"},
+				},
+			},
+			nil,
+			false,
+			time.Time{},
+		},
+		{
 			"ExtendedRule(+15s) GET 200 -> +15s",
 			&http.Request{
 				Method: http.MethodGet,


### PR DESCRIPTION
In RFC 9111, Servers that wish to control caching of responses with Set-Cookie headers are encouraged to emit appropriate Cache-Control response header fields (see https://httpwg.org/specs/rfc9111.html#rfc.section.7.3).
But to beat on the safe side, this package does not store responses with Set-Cookie headers by default, similar to NGINX.
THIS IS NOT RFC 9111.