### PR TITLE
If cache is not used, no Age header is given

### DIFF
--- a/rc_test.go
+++ b/rc_test.go
@@ -27,19 +27,19 @@ func TestRC(t *testing.T) {
 			{Method: http.MethodGet, URL: testutil.MustParseURL("http://example.com/1")},
 			{Method: http.MethodGet, URL: testutil.MustParseURL("http://example.com/2")},
 		}, []*http.Response{
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":1}`)},
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}, "X-Cache": []string{"HIT"}}, Body: testutil.NewBody(`{"count":1}`)},
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}, "X-Cache": []string{"HIT"}}, Body: testutil.NewBody(`{"count":1}`)},
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":2}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":1}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}, "X-Cache": []string{"HIT"}}, Body: testutil.NewBody(`{"count":1}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}, "X-Cache": []string{"HIT"}}, Body: testutil.NewBody(`{"count":1}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":2}`)},
 		}, 2},
 		{"all cache 2", testutil.NewAllCache(t), []*http.Request{
 			{Method: http.MethodGet, URL: testutil.MustParseURL("http://example.com/1")},
 			{Method: http.MethodGet, URL: testutil.MustParseURL("http://example.com/2")},
 			{Method: http.MethodGet, URL: testutil.MustParseURL("http://example.com/1")},
 		}, []*http.Response{
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":1}`)},
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":2}`)},
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}, "X-Cache": []string{"HIT"}}, Body: testutil.NewBody(`{"count":1}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":1}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":2}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}, "X-Cache": []string{"HIT"}}, Body: testutil.NewBody(`{"count":1}`)},
 		}, 1},
 		{"get only", testutil.NewGetOnlyCache(t), []*http.Request{
 			{Method: http.MethodPost, URL: testutil.MustParseURL("http://example.com/1")},
@@ -47,10 +47,10 @@ func TestRC(t *testing.T) {
 			{Method: http.MethodDelete, URL: testutil.MustParseURL("http://example.com/1")},
 			{Method: http.MethodGet, URL: testutil.MustParseURL("http://example.com/1")},
 		}, []*http.Response{
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":1}`)},
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":2}`)},
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":3}`)},
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}, "X-Cache": []string{"HIT"}}, Body: testutil.NewBody(`{"count":2}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":1}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":2}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":3}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}, "X-Cache": []string{"HIT"}}, Body: testutil.NewBody(`{"count":2}`)},
 		}, 1},
 	}
 	for _, tt := range tests {
@@ -123,10 +123,10 @@ func TestWithReverseProxy(t *testing.T) {
 			{Method: http.MethodGet, URL: testutil.MustParseURL("http://example.com/path/to/1")},
 			{Method: http.MethodGet, URL: testutil.MustParseURL("http://example.com/path/to/2")},
 		}, []*http.Response{
-			{StatusCode: http.StatusNotFound, Header: http.Header{"Age": []string{"0"}}, Body: testutil.NewBody(``)},
-			{StatusCode: http.StatusNotFound, Header: http.Header{"Age": []string{"0"}}, Body: testutil.NewBody(``)},
-			{StatusCode: http.StatusNotFound, Header: http.Header{"Age": []string{"0"}}, Body: testutil.NewBody(``)},
-			{StatusCode: http.StatusNotFound, Header: http.Header{"Age": []string{"0"}}, Body: testutil.NewBody(``)},
+			{StatusCode: http.StatusNotFound, Header: http.Header{}, Body: testutil.NewBody(``)},
+			{StatusCode: http.StatusNotFound, Header: http.Header{}, Body: testutil.NewBody(``)},
+			{StatusCode: http.StatusNotFound, Header: http.Header{}, Body: testutil.NewBody(``)},
+			{StatusCode: http.StatusNotFound, Header: http.Header{}, Body: testutil.NewBody(``)},
 		}, 0},
 		{"cache with reverse proxy", true, []*http.Request{
 			{Method: http.MethodGet, URL: testutil.MustParseURL("http://example.com/path/to/1")},
@@ -134,10 +134,10 @@ func TestWithReverseProxy(t *testing.T) {
 			{Method: http.MethodGet, URL: testutil.MustParseURL("http://example.com/path/to/1")},
 			{Method: http.MethodGet, URL: testutil.MustParseURL("http://example.com/path/to/2")},
 		}, []*http.Response{
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":1}`)},
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}, "X-Cache": []string{"HIT"}}, Body: testutil.NewBody(`{"count":1}`)},
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}, "X-Cache": []string{"HIT"}}, Body: testutil.NewBody(`{"count":1}`)},
-			{StatusCode: http.StatusOK, Header: http.Header{"Age": []string{"0"}, "Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":2}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":1}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}, "X-Cache": []string{"HIT"}}, Body: testutil.NewBody(`{"count":1}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}, "X-Cache": []string{"HIT"}}, Body: testutil.NewBody(`{"count":1}`)},
+			{StatusCode: http.StatusOK, Header: http.Header{"Cache-Control": []string{"max-age=60"}, "Content-Type": []string{"application/json"}}, Body: testutil.NewBody(`{"count":2}`)},
 		}, 2},
 	}
 	for _, tt := range tests {

--- a/rfc9111/age.go
+++ b/rfc9111/age.go
@@ -9,9 +9,7 @@ import (
 func setAgeHeader(useCached bool, resHeader http.Header, now time.Time) {
 	// 4.2.3. Calculating Age
 	if !useCached {
-		if resHeader.Get("Age") == "" {
-			resHeader.Set("Age", "0")
-		}
+		// The presence of an Age header field implies that the response was not generated or validated by the origin server for this request. However, lack of an Age header field does not imply the origin was contacted.
 		return
 	}
 	// The following is straight code with the expectation that it will be optimized by the compiler

--- a/rfc9111/age.go
+++ b/rfc9111/age.go
@@ -9,7 +9,7 @@ import (
 func setAgeHeader(useCached bool, resHeader http.Header, now time.Time) {
 	// 4.2.3. Calculating Age
 	if !useCached {
-		// The presence of an Age header field implies that the response was not generated or validated by the origin server for this request. However, lack of an Age header field does not imply the origin was contacted.
+		// The presence of an Age header field implies that the response was not generated or validated by the origin server for this request. However, lack of an Age header field does not imply the origin was contacted (https://httpwg.org/specs/rfc9111.html#rfc.section.5.1).
 		return
 	}
 	// The following is straight code with the expectation that it will be optimized by the compiler

--- a/rfc9111/age_test.go
+++ b/rfc9111/age_test.go
@@ -18,14 +18,12 @@ func TestSetAgeHeader(t *testing.T) {
 		wantHeader http.Header
 	}{
 		{
-			name:      "No cache and no Age header",
-			useCached: false,
-			resHeader: http.Header{},
-			now:       now,
-			wantAge:   "0",
-			wantHeader: http.Header{
-				"Age": []string{"0"},
-			},
+			name:       "No cache and no Age header",
+			useCached:  false,
+			resHeader:  http.Header{},
+			now:        now,
+			wantAge:    "",
+			wantHeader: http.Header{},
 		},
 		{
 			name:      "No cache and Age header +5sec",

--- a/rfc9111/shared_test.go
+++ b/rfc9111/shared_test.go
@@ -463,9 +463,7 @@ func TestShared_Handle(t *testing.T) {
 
 	origin200res := &http.Response{
 		StatusCode: http.StatusOK,
-		Header: http.Header{
-			"Age": []string{"0"},
-		},
+		Header:     http.Header{},
 	}
 	do200 := func(req *http.Request) (*http.Response, error) {
 		return &http.Response{


### PR DESCRIPTION
https://httpwg.org/specs/rfc9111.html#field.age

> The presence of an Age header field implies that the response was not generated or validated by the origin server for this request. However, lack of an Age header field does not imply the origin was contacted.