### PR TITLE
It is desirable that there should be no content body in the response, but the proxy server cannot handle it, so it is used as a debug log.

### DIFF
--- a/rc.go
+++ b/rc.go
@@ -134,13 +134,13 @@ func (m *cacheMw) Handler(next http.Handler) http.Handler {
 				// - "http2: stream closed": The client disconnected. (net/http.http2errStreamClosed)
 				// - syscall.ECONNRESET: The client disconnected. ("connection reset by peer")
 				// - syscall.EPIPE: The client disconnected. ("broken pipe")
-				// Error as warning
 				// - http.ErrBodyNotAllowed: The request method does not allow a body.
 				switch {
 				case errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || contains([]string{"client disconnected", "http2: stream closed"}, err.Error()):
 					m.logger.Debug("failed to write response body", slog.String("error", err.Error()), slog.String("host", preq.Host), slog.String("method", preq.Method), slog.String("url", preq.URL.String()), slog.Any("headers", m.maskHeader(preq.Header)), slog.Int("status", res.StatusCode), slog.Any("response_headers", m.maskHeader(res.Header)))
 				case errors.Is(err, http.ErrBodyNotAllowed):
-					m.logger.Warn("failed to write response body", slog.String("error", err.Error()), slog.String("host", preq.Host), slog.String("method", preq.Method), slog.String("url", preq.URL.String()), slog.Any("headers", m.maskHeader(preq.Header)), slog.Int("status", res.StatusCode), slog.Any("response_headers", m.maskHeader(res.Header)))
+					// It is desirable that there should be no content body in the response, but the proxy server cannot handle it, so it is used as a debug log.
+					m.logger.Debug("failed to write response body", slog.String("error", err.Error()), slog.String("host", preq.Host), slog.String("method", preq.Method), slog.String("url", preq.URL.String()), slog.Any("headers", m.maskHeader(preq.Header)), slog.Int("status", res.StatusCode), slog.Any("response_headers", m.maskHeader(res.Header)))
 				default:
 					m.logger.Error("failed to write response body", slog.String("error", err.Error()), slog.String("host", preq.Host), slog.String("method", preq.Method), slog.String("url", preq.URL.String()), slog.Any("headers", m.maskHeader(preq.Header)), slog.Int("status", res.StatusCode), slog.Any("response_headers", m.maskHeader(res.Header)))
 				}


### PR DESCRIPTION
SSIA.