### PR TITLE
If `rc.ErrShouldNotUseCache`, skip all caching processes.

### DIFF
--- a/rc.go
+++ b/rc.go
@@ -107,6 +107,9 @@ func (m *cacheMw) Handler(next http.Handler) http.Handler {
 				m.logger.Debug("cache expired", slog.String("host", preq.Host), slog.String("method", preq.Method), slog.String("url", preq.URL.String()), slog.Any("headers", m.maskHeader(preq.Header)))
 			case errors.Is(err, ErrShouldNotUseCache):
 				m.logger.Debug("should not use cache", slog.String("host", preq.Host), slog.String("method", preq.Method), slog.String("url", preq.URL.String()), slog.Any("headers", m.maskHeader(preq.Header)))
+				// Skip caching
+				next.ServeHTTP(w, req)
+				return
 			default:
 				m.logger.Error("failed to load cache", slog.String("error", err.Error()), slog.String("host", preq.Host), slog.String("method", preq.Method), slog.String("url", preq.URL.String()), slog.Any("headers", m.maskHeader(preq.Header)))
 			}

--- a/rc.go
+++ b/rc.go
@@ -24,8 +24,8 @@ var defaultHeaderNamesToMask = []string{
 type Cacher interface {
 	// Load loads the request/response cache.
 	// If the cache is not found, it returns ErrCacheNotFound.
-	// If not caching, it returns ErrNoCache.
 	// If the cache is expired, it returns ErrCacheExpired.
+	// If not caching, it returns ErrShouldNotUseCache.
 	Load(req *http.Request) (cachedReq *http.Request, cachedRes *http.Response, err error)
 	// Store stores the response cache.
 	Store(req *http.Request, res *http.Response, expires time.Time) error

--- a/testutil/cacher.go
+++ b/testutil/cacher.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/2manymws/rc"
 )
 
 var (
@@ -101,7 +103,7 @@ func NewGetOnlyCache(t testing.TB) *GetOnlyCache {
 func (c *GetOnlyCache) Load(req *http.Request) (*http.Request, *http.Response, error) {
 	c.t.Helper()
 	if req.Method != http.MethodGet {
-		return nil, nil, errNoCache
+		return nil, nil, rc.ErrShouldNotUseCache
 	}
 	key := reqToKey(req)
 	c.mu.Lock()


### PR DESCRIPTION
Previously, the cache process was passed through even if Cacher.Load returned `rc.ErrShouldNotUseCache`, but this fix skips it all.