### PR TITLE
Use io.CopyBuffer instead of io.ReadAll

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,4 @@
 run:
-  go: 1.21
   modules-download-mode: mod
 linters:
   fast: false
-linters-settings:
-  staticcheck:
-    go: 1.16
-issues:
-  exclude:
-    - SA3000

--- a/copybuf.go
+++ b/copybuf.go
@@ -1,0 +1,18 @@
+package rc
+
+import "sync"
+
+// Copy from net/http/server.go
+const copyBufPoolSize = 32 * 1024
+
+var copyBufPool = sync.Pool{New: func() any { return new([copyBufPoolSize]byte) }}
+
+func getCopyBuf() []byte {
+	return copyBufPool.Get().(*[copyBufPoolSize]byte)[:]
+}
+func putCopyBuf(b []byte) {
+	if len(b) != copyBufPoolSize {
+		panic("trying to put back buffer of the wrong size in the copyBufPool")
+	}
+	copyBufPool.Put((*[copyBufPoolSize]byte)(b))
+}

--- a/copybuf.go
+++ b/copybuf.go
@@ -7,12 +7,12 @@ const copyBufPoolSize = 32 * 1024
 
 var copyBufPool = sync.Pool{New: func() any { return new([copyBufPoolSize]byte) }}
 
-func getCopyBuf() []byte {
+func getCopyBuf() []byte { //nostyle:getters
 	return copyBufPool.Get().(*[copyBufPoolSize]byte)[:]
 }
 func putCopyBuf(b []byte) {
 	if len(b) != copyBufPoolSize {
-		panic("trying to put back buffer of the wrong size in the copyBufPool")
+		panic("trying to put back buffer of the wrong size in the copyBufPool") //nostyle:dontpanic
 	}
 	copyBufPool.Put((*[copyBufPoolSize]byte)(b))
 }

--- a/rc.go
+++ b/rc.go
@@ -135,6 +135,7 @@ func (m *cacheMw) Handler(next http.Handler) http.Handler {
 		ww := w.(io.Writer)
 		b := new(bytes.Buffer)
 		if !cacheUsed {
+			// If the cache is not used, duplicate the response body for caching.
 			ww = io.MultiWriter(ww, b)
 		}
 		buf := getCopyBuf()


### PR DESCRIPTION
Only if there is a cache hit, but memory efficiency is improved.